### PR TITLE
HW-2 : MODEL 구현 (이정태)

### DIFF
--- a/class13/CmplxN/AAS/app/build.gradle
+++ b/class13/CmplxN/AAS/app/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     // rcv
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
+    // fragment
+    implementation "androidx.fragment:fragment:1.2.5"
+    implementation "androidx.fragment:fragment-ktx:1.2.5"
+
     // glide
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     kapt 'com.github.bumptech.glide:compiler:4.11.0'

--- a/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
+++ b/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.example.aas">
+    package="com.example.aas">
 
-	<uses-permission android:name="android.permission.INTERNET" />
-	<application
-		android:name=".MyApplication"
-		android:allowBackup="true"
-		android:icon="@mipmap/ic_launcher"
-		android:label="@string/app_name"
-		android:roundIcon="@mipmap/ic_launcher_round"
-		android:supportsRtl="true"
-		android:theme="@style/AppTheme">
-		<activity android:name=".ui.MainActivity">
-			<intent-filter>
-				<action android:name="android.intent.action.MAIN" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+        android:name=".MyApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity android:name=".ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-				<category android:name="android.intent.category.LAUNCHER" />
-			</intent-filter>
-		</activity>
-	</application>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
+++ b/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:supportsRtl="true"
 		android:theme="@style/AppTheme">
-		<activity android:name=".MainActivity">
+		<activity android:name=".ui.MainActivity">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 

--- a/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
+++ b/class13/CmplxN/AAS/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application
+		android:name=".MyApplication"
 		android:allowBackup="true"
 		android:icon="@mipmap/ic_launcher"
 		android:label="@string/app_name"

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/MyApplication.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/MyApplication.kt
@@ -1,0 +1,17 @@
+package com.example.aas
+
+import android.app.Application
+import android.content.Context
+
+class MyApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        appContext = this
+    }
+
+    companion object {
+        lateinit var appContext: Context
+            private set
+    }
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/model/ApiResult.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/model/ApiResult.kt
@@ -1,4 +1,4 @@
-package com.example.aas
+package com.example.aas.data.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/model/Movie.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/model/Movie.kt
@@ -1,4 +1,4 @@
-package com.example.aas
+package com.example.aas.data.model
 
 data class Movie(
 	val actor: String,

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/network/NaverMoviesApi.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/network/NaverMoviesApi.kt
@@ -1,5 +1,6 @@
-package com.example.aas
+package com.example.aas.data.network
 
+import com.example.aas.data.model.ApiResult
 import io.reactivex.Single
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/network/RetrofitManager.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/network/RetrofitManager.kt
@@ -1,5 +1,6 @@
-package com.example.aas
+package com.example.aas.data.network
 
+import com.example.aas.BuildConfig
 import io.reactivex.schedulers.Schedulers
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
@@ -1,12 +1,11 @@
 package com.example.aas.data.repository
 
-import android.content.Context
 import com.example.aas.data.model.ApiResult
 import io.reactivex.Single
 
 interface MovieSearchRepository {
 
-    fun getMovies(query: String, context: Context): Single<ApiResult>
+    fun getMovies(query: String): Single<ApiResult>
 
-    fun getSavedQueries(context: Context): List<String>
+    fun getSavedQueries(): List<String>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
@@ -1,11 +1,12 @@
 package com.example.aas.data.repository
 
 import com.example.aas.data.model.ApiResult
+import io.reactivex.Completable
 import io.reactivex.Single
 
 interface MovieSearchRepository {
 
-    fun getMovies(query: String): Single<ApiResult>
+    fun getMovies(query: String): Single<Pair<ApiResult, Completable>>
 
-    fun getSavedQueries(): List<String>
+    fun getSavedQueries(): Single<List<String>>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
@@ -1,12 +1,11 @@
 package com.example.aas.data.repository
 
 import com.example.aas.data.model.ApiResult
-import io.reactivex.Completable
 import io.reactivex.Single
 
 interface MovieSearchRepository {
 
-    fun getMovies(query: String): Single<Pair<ApiResult, Completable>>
+    fun getMovies(query: String): Single<ApiResult>
 
     fun getSavedQueries(): Single<List<String>>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
@@ -8,4 +8,6 @@ interface MovieSearchRepository {
     fun getMovies(query: String): Single<ApiResult>
 
     fun getSavedQueries(): Single<List<String>>
+
+    fun onDestroy()
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepository.kt
@@ -1,0 +1,12 @@
+package com.example.aas.data.repository
+
+import android.content.Context
+import com.example.aas.data.model.ApiResult
+import io.reactivex.Single
+
+interface MovieSearchRepository {
+
+    fun getMovies(query: String, context: Context): Single<ApiResult>
+
+    fun getSavedQueries(context: Context): List<String>
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -5,18 +5,15 @@ import com.example.aas.data.source.local.LocalDataSource
 import com.example.aas.data.source.local.LocalDataSourceImpl
 import com.example.aas.data.source.remote.RemoteDataSource
 import com.example.aas.data.source.remote.RemoteDataSourceImpl
-import io.reactivex.Completable
 import io.reactivex.Single
 
 object MovieSearchRepositoryImpl : MovieSearchRepository {
     private val localDataSource: LocalDataSource = LocalDataSourceImpl()
     private val remoteDataSource: RemoteDataSource = RemoteDataSourceImpl()
 
-    override fun getMovies(query: String): Single<Pair<ApiResult, Completable>> {
+    override fun getMovies(query: String): Single<ApiResult> {
         return remoteDataSource.getMovies(query)
-            .flatMap {
-                Single.just(Pair(it, localDataSource.saveQuery(query)))
-            }
+            .doOnSuccess { localDataSource.saveQuery(query) }
     }
 
     override fun getSavedQueries(): Single<List<String>> = localDataSource.getSavedQuery()

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.example.aas.data.repository
+
+import android.content.Context
+import com.example.aas.data.model.ApiResult
+import com.example.aas.data.source.local.LocalDataSource
+import com.example.aas.data.source.local.LocalDataSourceImpl
+import com.example.aas.data.source.remote.RemoteDataSource
+import com.example.aas.data.source.remote.RemoteDataSourceImpl
+import io.reactivex.Single
+
+object MovieSearchRepositoryImpl : MovieSearchRepository {
+    private val localDataSource: LocalDataSource = LocalDataSourceImpl()
+    private val remoteDataSource: RemoteDataSource = RemoteDataSourceImpl()
+
+    override fun getMovies(query: String, context: Context): Single<ApiResult> {
+        localDataSource.saveQuery(query, context)
+        return remoteDataSource.getMovies(query)
+    }
+
+    override fun getSavedQueries(context: Context): List<String> {
+        return localDataSource.getSavedQuery(context)
+    }
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -17,4 +17,8 @@ object MovieSearchRepositoryImpl : MovieSearchRepository {
     }
 
     override fun getSavedQueries(): Single<List<String>> = localDataSource.getSavedQuery()
+
+    override fun onDestroy() {
+        localDataSource.onDestroy()
+    }
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -5,18 +5,19 @@ import com.example.aas.data.source.local.LocalDataSource
 import com.example.aas.data.source.local.LocalDataSourceImpl
 import com.example.aas.data.source.remote.RemoteDataSource
 import com.example.aas.data.source.remote.RemoteDataSourceImpl
+import io.reactivex.Completable
 import io.reactivex.Single
 
 object MovieSearchRepositoryImpl : MovieSearchRepository {
     private val localDataSource: LocalDataSource = LocalDataSourceImpl()
     private val remoteDataSource: RemoteDataSource = RemoteDataSourceImpl()
 
-    override fun getMovies(query: String): Single<ApiResult> {
+    override fun getMovies(query: String): Single<Pair<ApiResult, Completable>> {
         return remoteDataSource.getMovies(query)
-            .doOnSuccess {
-                localDataSource.saveQuery(query)
+            .flatMap {
+                Single.just(Pair(it, localDataSource.saveQuery(query)))
             }
     }
 
-    override fun getSavedQueries(): List<String> = localDataSource.getSavedQuery()
+    override fun getSavedQueries(): Single<List<String>> = localDataSource.getSavedQuery()
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.aas.data.repository
 
-import android.content.Context
 import com.example.aas.data.model.ApiResult
 import com.example.aas.data.source.local.LocalDataSource
 import com.example.aas.data.source.local.LocalDataSourceImpl
@@ -12,12 +11,12 @@ object MovieSearchRepositoryImpl : MovieSearchRepository {
     private val localDataSource: LocalDataSource = LocalDataSourceImpl()
     private val remoteDataSource: RemoteDataSource = RemoteDataSourceImpl()
 
-    override fun getMovies(query: String, context: Context): Single<ApiResult> {
-        localDataSource.saveQuery(query, context)
+    override fun getMovies(query: String): Single<ApiResult> {
+        localDataSource.saveQuery(query)
         return remoteDataSource.getMovies(query)
     }
 
-    override fun getSavedQueries(context: Context): List<String> =
-        localDataSource.getSavedQuery(context)
+    override fun getSavedQueries(): List<String> =
+        localDataSource.getSavedQuery()
 
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -12,11 +12,11 @@ object MovieSearchRepositoryImpl : MovieSearchRepository {
     private val remoteDataSource: RemoteDataSource = RemoteDataSourceImpl()
 
     override fun getMovies(query: String): Single<ApiResult> {
-        localDataSource.saveQuery(query)
         return remoteDataSource.getMovies(query)
+            .doOnSuccess {
+                localDataSource.saveQuery(query)
+            }
     }
 
-    override fun getSavedQueries(): List<String> =
-        localDataSource.getSavedQuery()
-
+    override fun getSavedQueries(): List<String> = localDataSource.getSavedQuery()
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/repository/MovieSearchRepositoryImpl.kt
@@ -17,7 +17,7 @@ object MovieSearchRepositoryImpl : MovieSearchRepository {
         return remoteDataSource.getMovies(query)
     }
 
-    override fun getSavedQueries(context: Context): List<String> {
-        return localDataSource.getSavedQuery(context)
-    }
+    override fun getSavedQueries(context: Context): List<String> =
+        localDataSource.getSavedQuery(context)
+
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
@@ -1,7 +1,10 @@
 package com.example.aas.data.source.local
 
-interface LocalDataSource {
-    fun saveQuery(query: String)
+import io.reactivex.Completable
+import io.reactivex.Single
 
-    fun getSavedQuery(): List<String>
+interface LocalDataSource {
+    fun saveQuery(query: String): Completable
+
+    fun getSavedQuery(): Single<List<String>>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
@@ -6,4 +6,6 @@ interface LocalDataSource {
     fun saveQuery(query: String)
 
     fun getSavedQuery(): Single<List<String>>
+
+    fun onDestroy()
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
@@ -1,0 +1,9 @@
+package com.example.aas.data.source.local
+
+import android.content.Context
+
+interface LocalDataSource {
+    fun saveQuery(query: String, context: Context)
+
+    fun getSavedQuery(context: Context): List<String>
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
@@ -1,10 +1,9 @@
 package com.example.aas.data.source.local
 
-import io.reactivex.Completable
 import io.reactivex.Single
 
 interface LocalDataSource {
-    fun saveQuery(query: String): Completable
+    fun saveQuery(query: String)
 
     fun getSavedQuery(): Single<List<String>>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSource.kt
@@ -1,9 +1,7 @@
 package com.example.aas.data.source.local
 
-import android.content.Context
-
 interface LocalDataSource {
-    fun saveQuery(query: String, context: Context)
+    fun saveQuery(query: String)
 
-    fun getSavedQuery(context: Context): List<String>
+    fun getSavedQuery(): List<String>
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -2,16 +2,19 @@ package com.example.aas.data.source.local
 
 import android.content.Context
 import androidx.core.content.edit
+import com.example.aas.MyApplication
 import org.json.JSONArray
 import org.json.JSONException
 
 class LocalDataSourceImpl : LocalDataSource {
 
-    override fun saveQuery(query: String, context: Context) {
-        val queryHistorySharedPreferences =
-            context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+    override fun saveQuery(query: String) {
+        val appContext = MyApplication.appContext
 
-        val currentState = getSavedQuery(context).toMutableList()
+        val queryHistorySharedPreferences =
+            appContext.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+
+        val currentState = getSavedQuery().toMutableList()
         if (!currentState.remove(query) && currentState.size > 4) {
             currentState.removeFirstOrNull()
         }
@@ -24,9 +27,11 @@ class LocalDataSourceImpl : LocalDataSource {
         }
     }
 
-    override fun getSavedQuery(context: Context): List<String> {
+    override fun getSavedQuery(): List<String> {
+        val appContext = MyApplication.appContext
+
         val queryHistorySharedPreferences =
-            context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+            appContext.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
 
         val result = mutableListOf<String>()
 

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -18,9 +18,7 @@ class LocalDataSourceImpl : LocalDataSource {
 
         val editor = queryHistorySharedPreferences.edit()
         val editArray = JSONArray()
-        currentState.forEach {
-            editArray.put(it)
-        }
+        currentState.forEach { editArray.put(it) }
         editor.putString(sharedPreferencesName, editArray.toString())
         editor.apply()
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.example.aas.data.source.local
 
 import android.content.Context
+import androidx.core.content.edit
 import org.json.JSONArray
 import org.json.JSONException
 
@@ -16,11 +17,11 @@ class LocalDataSourceImpl : LocalDataSource {
         }
         currentState.add(query)
 
-        val editor = queryHistorySharedPreferences.edit()
-        val editArray = JSONArray()
-        currentState.forEach { editArray.put(it) }
-        editor.putString(sharedPreferencesName, editArray.toString())
-        editor.apply()
+        queryHistorySharedPreferences.edit {
+            val editArray = JSONArray()
+            currentState.forEach { editArray.put(it) }
+            putString(sharedPreferencesName, editArray.toString())
+        }
     }
 
     override fun getSavedQuery(context: Context): List<String> {

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -3,37 +3,43 @@ package com.example.aas.data.source.local
 import android.content.Context
 import androidx.core.content.edit
 import com.example.aas.MyApplication
+import io.reactivex.Completable
+import io.reactivex.Single
 import org.json.JSONArray
 import org.json.JSONException
 
 class LocalDataSourceImpl : LocalDataSource {
 
-    override fun saveQuery(query: String) {
+    override fun saveQuery(query: String): Completable {
         val appContext = MyApplication.appContext
 
         val queryHistorySharedPreferences =
             appContext.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
 
-        val currentState = getSavedQuery().toMutableList()
-        if (!currentState.remove(query) && currentState.size > 4) {
-            currentState.removeFirstOrNull()
-        }
-        currentState.add(query)
+        return getSavedQuery()
+            .flatMapCompletable {
+                val list = it.toMutableList()
+                if (!list.remove(query) && it.size > 4) {
+                    list.removeFirstOrNull()
+                }
+                list.add(query)
 
-        queryHistorySharedPreferences.edit {
-            val editArray = JSONArray()
-            currentState.forEach { editArray.put(it) }
-            putString(sharedPreferencesName, editArray.toString())
-        }
+                queryHistorySharedPreferences.edit {
+                    val editArray = JSONArray()
+                    list.forEach { query -> editArray.put(query) }
+                    putString(sharedPreferencesName, editArray.toString())
+                }
+                Completable.complete()
+            }
     }
 
-    override fun getSavedQuery(): List<String> {
+    override fun getSavedQuery(): Single<List<String>> {
         val appContext = MyApplication.appContext
 
         val queryHistorySharedPreferences =
             appContext.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
 
-        val result = mutableListOf<String>()
+        val result = arrayListOf<String>()
 
         queryHistorySharedPreferences.getString(sharedPreferencesName, null)?.let {
             try {
@@ -45,7 +51,7 @@ class LocalDataSourceImpl : LocalDataSource {
                 e.printStackTrace()
             }
         }
-        return result
+        return Single.just(result)
     }
 
     companion object {

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -1,0 +1,50 @@
+package com.example.aas.data.source.local
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONException
+
+class LocalDataSourceImpl : LocalDataSource {
+
+    override fun saveQuery(query: String, context: Context) {
+        val queryHistorySharedPreferences =
+            context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+
+        val currentState = getSavedQuery(context).toMutableList()
+        if (!currentState.remove(query) && currentState.size > 4) {
+            currentState.removeFirstOrNull()
+        }
+        currentState.add(query)
+
+        val editor = queryHistorySharedPreferences.edit()
+        val editArray = JSONArray()
+        currentState.forEach {
+            editArray.put(it)
+        }
+        editor.putString(sharedPreferencesName, editArray.toString())
+        editor.apply()
+    }
+
+    override fun getSavedQuery(context: Context): List<String> {
+        val queryHistorySharedPreferences =
+            context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+
+        val result = mutableListOf<String>()
+
+        queryHistorySharedPreferences.getString(sharedPreferencesName, null)?.let {
+            try {
+                val arr = JSONArray(it)
+                for (i in 0 until arr.length()) {
+                    result.add(arr.getString(i))
+                }
+            } catch (e: JSONException) {
+                e.printStackTrace()
+            }
+        }
+        return result
+    }
+
+    companion object {
+        const val sharedPreferencesName = "QueryHistory"
+    }
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/local/LocalDataSourceImpl.kt
@@ -4,11 +4,15 @@ import android.content.Context
 import androidx.core.content.edit
 import com.example.aas.MyApplication
 import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
 import org.json.JSONArray
 import org.json.JSONException
 import java.util.concurrent.TimeUnit
 
 class LocalDataSourceImpl : LocalDataSource {
+
+    private val compositeDisposable = CompositeDisposable()
 
     override fun saveQuery(query: String) {
         val appContext = MyApplication.appContext
@@ -32,7 +36,7 @@ class LocalDataSourceImpl : LocalDataSource {
                 }
             }, {
                 it.printStackTrace()
-            })
+            }).addTo(compositeDisposable)
     }
 
     override fun getSavedQuery(): Single<List<String>> {
@@ -54,6 +58,10 @@ class LocalDataSourceImpl : LocalDataSource {
             }
         }
         return Single.just(result)
+    }
+
+    override fun onDestroy() {
+        compositeDisposable.clear()
     }
 
     companion object {

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSource.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.aas.data.source.remote
+
+import com.example.aas.data.model.ApiResult
+import io.reactivex.Single
+
+interface RemoteDataSource {
+    fun getMovies(query: String): Single<ApiResult>
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSourceImpl.kt
@@ -5,7 +5,6 @@ import com.example.aas.data.network.RetrofitManager
 import io.reactivex.Single
 
 class RemoteDataSourceImpl : RemoteDataSource {
-    override fun getMovies(query: String): Single<ApiResult> {
-        return RetrofitManager.naverMoviesApi.getMovies(query)
-    }
+    override fun getMovies(query: String): Single<ApiResult> =
+        RetrofitManager.naverMoviesApi.getMovies(query)
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSourceImpl.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/data/source/remote/RemoteDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.example.aas.data.source.remote
+
+import com.example.aas.data.model.ApiResult
+import com.example.aas.data.network.RetrofitManager
+import io.reactivex.Single
+
+class RemoteDataSourceImpl : RemoteDataSource {
+    override fun getMovies(query: String): Single<ApiResult> {
+        return RetrofitManager.naverMoviesApi.getMovies(query)
+    }
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/HistorySelectionListener.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/HistorySelectionListener.kt
@@ -1,5 +1,0 @@
-package com.example.aas.ui
-
-interface HistorySelectionListener {
-    fun onHistorySelection(query: String)
-}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/HistorySelectionListener.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/HistorySelectionListener.kt
@@ -1,0 +1,5 @@
+package com.example.aas.ui
+
+interface HistorySelectionListener {
+    fun onHistorySelection(query: String)
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -65,6 +65,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
             .subscribe({
                 Toast.makeText(this@MainActivity, "Search Completed", Toast.LENGTH_SHORT).show()
                 movieAdapter.setList(it.movies)
+                btn_history.isEnabled = true
             }, {
                 Toast.makeText(this@MainActivity, "Network Error", Toast.LENGTH_LONG).show()
                 it.printStackTrace()

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -4,7 +4,8 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.aas.R
-import com.example.aas.data.network.RetrofitManager
+import com.example.aas.data.repository.MovieSearchRepository
+import com.example.aas.data.repository.MovieSearchRepositoryImpl
 import com.example.aas.utils.hideKeyboard
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
@@ -12,10 +13,13 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.concurrent.TimeUnit
 
-class MainActivity : AppCompatActivity(R.layout.activity_main) {
+class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelectionListener {
     private val compositeDisposable = CompositeDisposable()
+    private val movieSearchRepository: MovieSearchRepository = MovieSearchRepositoryImpl
     private val movieAdapter = MovieAdapter()
+    private val savedQueryDialogFragment by lazy { SavedQueryDialogFragment.getInstance(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,7 +35,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
                 val keyword = et_movie_name.text.also { et_movie_name.setText("") }
                 et_movie_name.clearFocus()
                 hideKeyboard(this, et_movie_name)
-                RetrofitManager.naverMoviesApi.getMovies(keyword.toString())
+                movieSearchRepository.getMovies(keyword.toString(), applicationContext)
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
@@ -41,10 +45,30 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
                 Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
                 it.printStackTrace()
             }).addTo(compositeDisposable)
+
+        btn_history.isEnabled =
+            movieSearchRepository.getSavedQueries(applicationContext).isNotEmpty()
+
+        RxView.clicks(btn_history)
+            .throttleFirst(1000L, TimeUnit.MILLISECONDS)
+            .subscribe { savedQueryDialogFragment.show(supportFragmentManager, "history") }
+            .addTo(compositeDisposable)
     }
 
     override fun onDestroy() {
         compositeDisposable.clear()
         super.onDestroy()
+    }
+
+    override fun onHistorySelection(query: String) {
+        movieSearchRepository.getMovies(query, applicationContext)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe({
+                Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
+                movieAdapter.setList(it.movies)
+            }, {
+                Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
+                it.printStackTrace()
+            }).addTo(compositeDisposable)
     }
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -14,7 +14,6 @@ import com.example.aas.utils.hideKeyboard
 import com.example.aas.utils.showToast
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
-import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -77,24 +76,13 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
             .observeGetMovies()
     }
 
-    private fun Observable<Pair<ApiResult, Completable>>.observeGetMovies() {
+    private fun Observable<ApiResult>.observeGetMovies() {
         this.observeOn(AndroidSchedulers.mainThread())
             .subscribe({
                 this@MainActivity.showToast("Search Completed", Toast.LENGTH_SHORT)
-                movieAdapter.setList(it.first.movies)
-                saveQuery(it.second)
+                movieAdapter.setList(it.movies)
             }, {
                 this@MainActivity.showToast("Network Error", Toast.LENGTH_LONG)
-                it.printStackTrace()
-            }).addTo(compositeDisposable)
-    }
-
-    private fun saveQuery(completable: Completable) {
-        completable
-            .subscribe({
-                this.showToast("save query Completed", Toast.LENGTH_SHORT)
-            }, {
-                this.showToast("save query Failed", Toast.LENGTH_LONG)
                 it.printStackTrace()
             }).addTo(compositeDisposable)
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
             }).addTo(compositeDisposable)
 
         btn_history.isEnabled =
-            movieSearchRepository.getSavedQueries(applicationContext).isNotEmpty()
+            movieSearchRepository.getSavedQueries(this).isNotEmpty()
 
         RxView.clicks(btn_history)
             .throttleFirst(1000L, TimeUnit.MILLISECONDS)
@@ -61,7 +61,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
     }
 
     override fun onHistorySelection(query: String) {
-        movieSearchRepository.getMovies(query, applicationContext)
+        movieSearchRepository.getMovies(query, this)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
                 Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -42,11 +42,11 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
                 val keyword = et_movie_name.text.also { et_movie_name.setText("") }
                 et_movie_name.clearFocus()
                 hideKeyboard(this, et_movie_name)
-                movieSearchRepository.getMovies(keyword.toString(), applicationContext)
+                movieSearchRepository.getMovies(keyword.toString())
             }
             .observeGetMovies()
 
-        btn_history.isEnabled = movieSearchRepository.getSavedQueries(this).isNotEmpty()
+        btn_history.isEnabled = movieSearchRepository.getSavedQueries().isNotEmpty()
 
         RxView.clicks(btn_history)
             .throttleFirst(1000L, TimeUnit.MILLISECONDS)
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
     }
 
     override fun onHistorySelection(query: String) {
-        movieSearchRepository.getMovies(query, this)
+        movieSearchRepository.getMovies(query)
             .toObservable()
             .observeGetMovies()
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
     }
 
     override fun onDestroy() {
+        movieSearchRepository.onDestroy()
         compositeDisposable.clear()
         super.onDestroy()
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -46,8 +46,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
                 it.printStackTrace()
             }).addTo(compositeDisposable)
 
-        btn_history.isEnabled =
-            movieSearchRepository.getSavedQueries(this).isNotEmpty()
+        btn_history.isEnabled = movieSearchRepository.getSavedQueries(this).isNotEmpty()
 
         RxView.clicks(btn_history)
             .throttleFirst(1000L, TimeUnit.MILLISECONDS)

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
     private val compositeDisposable = CompositeDisposable()
     private val movieSearchRepository: MovieSearchRepository = MovieSearchRepositoryImpl
     private val movieAdapter = MovieAdapter()
-    private val savedQueryDialogFragment by lazy { SavedQueryDialogFragment.getInstance(this) }
+    private val savedQueryDialogFragment by lazy { SavedQueryDialogFragment.create(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.aas.R
+import com.example.aas.data.model.ApiResult
 import com.example.aas.data.repository.MovieSearchRepository
 import com.example.aas.data.repository.MovieSearchRepositoryImpl
 import com.example.aas.utils.hideKeyboard
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
+import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
@@ -37,14 +39,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
                 hideKeyboard(this, et_movie_name)
                 movieSearchRepository.getMovies(keyword.toString(), applicationContext)
             }
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe({
-                Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
-                movieAdapter.setList(it.movies)
-            }, {
-                Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
-                it.printStackTrace()
-            }).addTo(compositeDisposable)
+            .observeGetMovies()
 
         btn_history.isEnabled = movieSearchRepository.getSavedQueries(this).isNotEmpty()
 
@@ -61,12 +56,17 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), HistorySelection
 
     override fun onHistorySelection(query: String) {
         movieSearchRepository.getMovies(query, this)
-            .observeOn(AndroidSchedulers.mainThread())
+            .toObservable()
+            .observeGetMovies()
+    }
+
+    private fun Observable<ApiResult>.observeGetMovies() {
+        this.observeOn(AndroidSchedulers.mainThread())
             .subscribe({
-                Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@MainActivity, "Search Completed", Toast.LENGTH_SHORT).show()
                 movieAdapter.setList(it.movies)
             }, {
-                Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
+                Toast.makeText(this@MainActivity, "Network Error", Toast.LENGTH_LONG).show()
                 it.printStackTrace()
             }).addTo(compositeDisposable)
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MainActivity.kt
@@ -1,8 +1,11 @@
-package com.example.aas
+package com.example.aas.ui
 
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.example.aas.R
+import com.example.aas.data.network.RetrofitManager
+import com.example.aas.utils.hideKeyboard
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -32,12 +35,12 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
-				Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
-				movieAdapter.setList(it.movies)
-			}, {
-				Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
-				it.printStackTrace()
-			}).addTo(compositeDisposable)
+                Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
+                movieAdapter.setList(it.movies)
+            }, {
+                Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
+                it.printStackTrace()
+            }).addTo(compositeDisposable)
     }
 
     override fun onDestroy() {

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieAdapter.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieAdapter.kt
@@ -1,9 +1,10 @@
-package com.example.aas
+package com.example.aas.ui
 
 import android.content.Intent
 import android.net.Uri
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.aas.data.model.Movie
 import com.jakewharton.rxbinding2.view.RxView
 import java.util.concurrent.TimeUnit
 

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieViewHolder.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieViewHolder.kt
@@ -1,9 +1,12 @@
-package com.example.aas
+package com.example.aas.ui
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.example.aas.data.model.Movie
+import com.example.aas.R
+import com.example.aas.utils.toHtml
 import kotlinx.android.synthetic.main.item_movie.view.*
 
 class MovieViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieViewHolder.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/MovieViewHolder.kt
@@ -3,14 +3,14 @@ package com.example.aas.ui
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.example.aas.data.model.Movie
 import com.example.aas.R
+import com.example.aas.data.model.Movie
+import com.example.aas.utils.glideCenterCrop
 import com.example.aas.utils.toHtml
 import kotlinx.android.synthetic.main.item_movie.view.*
 
 class MovieViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
-	LayoutInflater.from(parent.context).inflate(R.layout.item_movie, parent, false)
+    LayoutInflater.from(parent.context).inflate(R.layout.item_movie, parent, false)
 ) {
 
     private val movieImage = itemView.img_movie
@@ -20,11 +20,7 @@ class MovieViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
     private val movieRating = itemView.tv_rating
 
     fun bind(movie: Movie) {
-        Glide.with(movieImage.context)
-            .load(movie.image)
-            .centerCrop()
-            .into(movieImage)
-
+        movieImage.glideCenterCrop(movie.image)
         movieTitle.text = movie.title.toHtml()
         movieSubTitle.text = movie.subtitle.toHtml()
         movieActor.text = movie.actor.toHtml()

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -4,17 +4,14 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
-import com.example.aas.data.repository.MovieSearchRepository
-import com.example.aas.data.repository.MovieSearchRepositoryImpl
 
 class SavedQueryDialogFragment(private val historySelectionListener: HistorySelectionListener) :
     DialogFragment() {
 
-    private val movieSearchRepository: MovieSearchRepository = MovieSearchRepositoryImpl
     private lateinit var searchHistory: List<String>
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        searchHistory = movieSearchRepository.getSavedQueries().reversed()
+        searchHistory = arguments?.getStringArray(HISTORY_LIST)?.reversed() ?: listOf()
 
         return requireActivity().let {
             AlertDialog.Builder(it)
@@ -33,6 +30,9 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
     companion object {
         @Volatile
         private var INSTANCE: SavedQueryDialogFragment? = null
+
+        const val HISTORY_LIST = "historyList"
+        const val TAG = "history"
 
         fun getInstance(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment =
             INSTANCE ?: synchronized(this) {

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -14,7 +14,7 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
     private lateinit var searchHistory: List<String>
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        searchHistory = movieSearchRepository.getSavedQueries(requireContext()).reversed()
+        searchHistory = movieSearchRepository.getSavedQueries().reversed()
 
         return requireActivity().let {
             AlertDialog.Builder(it)

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -14,8 +14,8 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
     private lateinit var searchHistory: List<String>
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        searchHistory =
-            movieSearchRepository.getSavedQueries(requireContext()).reversed()
+        searchHistory = movieSearchRepository.getSavedQueries(requireContext()).reversed()
+
         return requireActivity().let {
             AlertDialog.Builder(it)
                 .setTitle("최근 5개 검색어")

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -17,17 +17,17 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
         searchHistory =
             movieSearchRepository.getSavedQueries(requireContext()).reversed()
         return requireActivity().let {
-            val builder = AlertDialog.Builder(it)
-            builder.setTitle("최근 5개 검색어")
+            AlertDialog.Builder(it)
+                .setTitle("최근 5개 검색어")
                 .setItems(searchHistory.toTypedArray()) { _, idx ->
                     historySelectionListener.onHistorySelection(searchHistory[idx])
                 }
-            builder.create()
+                .create()
         }
     }
 
     companion object {
-        fun getInstance(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment {
+        fun create(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment {
             return SavedQueryDialogFragment(historySelectionListener)
         }
     }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -15,7 +15,7 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         searchHistory =
-            movieSearchRepository.getSavedQueries(requireActivity().applicationContext).reversed()
+            movieSearchRepository.getSavedQueries(requireContext()).reversed()
         return requireActivity().let {
             val builder = AlertDialog.Builder(it)
             builder.setTitle("최근 5개 검색어")

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -1,0 +1,34 @@
+package com.example.aas.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.example.aas.data.repository.MovieSearchRepository
+import com.example.aas.data.repository.MovieSearchRepositoryImpl
+
+class SavedQueryDialogFragment(private val historySelectionListener: HistorySelectionListener) :
+    DialogFragment() {
+
+    private val movieSearchRepository: MovieSearchRepository = MovieSearchRepositoryImpl
+    private lateinit var searchHistory: List<String>
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        searchHistory =
+            movieSearchRepository.getSavedQueries(requireActivity().applicationContext).reversed()
+        return requireActivity().let {
+            val builder = AlertDialog.Builder(it)
+            builder.setTitle("최근 5개 검색어")
+                .setItems(searchHistory.toTypedArray()) { _, idx ->
+                    historySelectionListener.onHistorySelection(searchHistory[idx])
+                }
+            builder.create()
+        }
+    }
+
+    companion object {
+        fun getInstance(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment {
+            return SavedQueryDialogFragment(historySelectionListener)
+        }
+    }
+}

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/ui/SavedQueryDialogFragment.kt
@@ -26,9 +26,17 @@ class SavedQueryDialogFragment(private val historySelectionListener: HistorySele
         }
     }
 
+    interface HistorySelectionListener {
+        fun onHistorySelection(query: String)
+    }
+
     companion object {
-        fun create(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment {
-            return SavedQueryDialogFragment(historySelectionListener)
-        }
+        @Volatile
+        private var INSTANCE: SavedQueryDialogFragment? = null
+
+        fun getInstance(historySelectionListener: HistorySelectionListener): SavedQueryDialogFragment =
+            INSTANCE ?: synchronized(this) {
+                SavedQueryDialogFragment(historySelectionListener).also { INSTANCE = it }
+            }
     }
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
@@ -1,4 +1,4 @@
-package com.example.aas
+package com.example.aas.utils
 
 import android.content.Context
 import android.os.Build

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
@@ -6,6 +6,8 @@ import android.text.Html
 import android.text.Spanned
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.ImageView
+import com.bumptech.glide.Glide
 
 fun String.toHtml(): Spanned {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
@@ -17,4 +19,11 @@ fun String.toHtml(): Spanned {
 fun hideKeyboard(context: Context, view: View) {
     val inputMethod = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethod.hideSoftInputFromWindow(view.windowToken, 0)
+}
+
+fun ImageView.glideCenterCrop(uri: String) {
+    Glide.with(this)
+        .load(uri)
+        .centerCrop()
+        .into(this)
 }

--- a/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
+++ b/class13/CmplxN/AAS/app/src/main/java/com/example/aas/utils/Util.kt
@@ -7,6 +7,7 @@ import android.text.Spanned
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
+import android.widget.Toast
 import com.bumptech.glide.Glide
 
 fun String.toHtml(): Spanned {
@@ -26,4 +27,8 @@ fun ImageView.glideCenterCrop(uri: String) {
         .load(uri)
         .centerCrop()
         .into(this)
+}
+
+fun Context.showToast(message: String, duration: Int) {
+    Toast.makeText(this, message, duration).show()
 }

--- a/class13/CmplxN/AAS/app/src/main/res/layout/activity_main.xml
+++ b/class13/CmplxN/AAS/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".ui.MainActivity">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"

--- a/class13/CmplxN/AAS/app/src/main/res/layout/activity_main.xml
+++ b/class13/CmplxN/AAS/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,15 @@
         android:enabled="false"
         android:text="검색"
         app:layout_constraintBottom_toBottomOf="@id/guideline"
+        app:layout_constraintEnd_toStartOf="@+id/btn_history"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btn_history"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="기록"
+        app:layout_constraintBottom_toBottomOf="@id/guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
Local은 SharedPreferences로 했고, data가 작아서 Local query 저장 / 불러오기는 UI Thread에서 했습니다.


Q : Observable과 Single에 중복되는
```kotlin
.observeOn(AndroidSchedulers.mainThread())
.subscribe({
    Toast.makeText(this, "Search Completed", Toast.LENGTH_SHORT).show()
    movieAdapter.setList(it.movies)
}, {
    Toast.makeText(this, "Network Error", Toast.LENGTH_LONG).show()
    it.printStackTrace()
}).addTo(compositeDisposable)
```
이 부분을 Observable과 Single을 한번에 Extension Function으로 중복을 줄여보고 싶은데 불가능한가요?